### PR TITLE
Replace pycrypto with pycryptodome

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ you can use it from the command-line::
     beefish.py -e secrets.txt secrets.enc
     beefish.py -d secrets.enc secrets.dec
 
-to use AES-256 cipher instead of the default, which is blowfish:
+to use AES-256 cipher instead of the default, which is blowfish::
 
     beefish.py -a -e secrets.txt
     beefish.py -a -d secrets.encrypted

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 beefish
 =======
 
-Easy file encryption using pycrypto
+Easy file encryption using pycryptodome
 
 .. image:: http://media.charlesleifer.com/blog/photos/beefish.jpg
 
@@ -11,7 +11,7 @@ installing
 
 ::
 
-    pip install beefish pycrypto
+    pip install beefish pycryptodome
 
 Alternatively::
 
@@ -19,7 +19,7 @@ Alternatively::
 
 Dependencies:
 
-* `pycrypto <https://www.dlitz.net/software/pycrypto/>`_
+* `pycryptodome <https://www.pycryptodome.org/>`_
 
 
 command-line options

--- a/beefish.py
+++ b/beefish.py
@@ -35,6 +35,16 @@ CIPHER_BLOWFISH = 1
 CIPHER_AES = 2
 
 
+def _to_bytes(data, encoding="utf-8"):
+    """Converts given string to bytes using given encoding.
+    Default encoding is "utf-8"."""
+    if isinstance(data, bytes):
+        return data
+
+    if isinstance(data, str):
+        return data.encode(encoding, errors="replace")
+
+
 def _gen_padding(file_size, block_size):
     pad_bytes = block_size - (file_size % block_size)
     padding = Random.get_random_bytes(pad_bytes - 1)
@@ -49,7 +59,7 @@ def generate_iv(block_size):
     return Random.get_random_bytes(block_size)
 
 def get_blowfish_cipher(key, iv):
-    return Blowfish.new(tobytes(key), Blowfish.MODE_CBC, iv)
+    return Blowfish.new(_to_bytes(key), Blowfish.MODE_CBC, iv)
 
 def get_aes_cipher(key, iv):
     if isinstance(key, unicode_type):
@@ -65,23 +75,12 @@ def get_aes_cipher(key, iv):
 
     new_key = d[:key_length]
     new_iv = d[key_length:key_iv_length]
-    return AES.new(tobytes(new_key), AES.MODE_CBC, new_iv)
+    return AES.new(_to_bytes(new_key), AES.MODE_CBC, new_iv)
 
 CIPHER_MAP = {
     CIPHER_BLOWFISH: (get_blowfish_cipher, Blowfish.block_size),
     CIPHER_AES: (get_aes_cipher, AES.block_size),
 }
-
-
-def tobytes(data, encoding="utf-8"):
-    """Converts given string to bytes using given encoding.
-    Default encoding is "utf-8"."""
-    if isinstance(data, bytes):
-        return data
-
-    if isinstance(data, str):
-        return data.encode(encoding, errors="replace")
-
 
 def encrypt(in_buf, out_buf, key, chunk_size=4096,
             cipher_type=CIPHER_BLOWFISH):

--- a/beefish.py
+++ b/beefish.py
@@ -13,11 +13,6 @@ if PY3:
     print_ = getattr(builtins, 'print')
     raw_input = getattr(builtins, 'input')
     unicode_type = str
-    # PyCrypto uses time.clock internally, which was removed in 3.8. We'll just
-    # patch it in for now.
-    if sys.version_info >= (3, 8, 0):
-        import time
-        time.clock = time.process_time
 else:
     unicode_type = unicode
     def print_(s):

--- a/beefish.py
+++ b/beefish.py
@@ -2,7 +2,6 @@
 import getpass
 import optparse
 import os
-import struct
 import sys
 import unittest
 from hashlib import sha256

--- a/beefish.py
+++ b/beefish.py
@@ -50,7 +50,7 @@ def generate_iv(block_size):
     return Random.get_random_bytes(block_size)
 
 def get_blowfish_cipher(key, iv):
-    return Blowfish.new(key, Blowfish.MODE_CBC, iv)
+    return Blowfish.new(tobytes(key), Blowfish.MODE_CBC, iv)
 
 def get_aes_cipher(key, iv):
     if isinstance(key, unicode_type):
@@ -66,12 +66,23 @@ def get_aes_cipher(key, iv):
 
     new_key = d[:key_length]
     new_iv = d[key_length:key_iv_length]
-    return AES.new(new_key, AES.MODE_CBC, new_iv)
+    return AES.new(tobytes(new_key), AES.MODE_CBC, new_iv)
 
 CIPHER_MAP = {
     CIPHER_BLOWFISH: (get_blowfish_cipher, Blowfish.block_size),
     CIPHER_AES: (get_aes_cipher, AES.block_size),
 }
+
+
+def tobytes(data, encoding="utf-8"):
+    """Converts given string to bytes using given encoding.
+    Default encoding is "utf-8"."""
+    if isinstance(data, bytes):
+        return data
+
+    if isinstance(data, str):
+        return data.encode(encoding, errors="replace")
+
 
 def encrypt(in_buf, out_buf, key, chunk_size=4096,
             cipher_type=CIPHER_BLOWFISH):
@@ -215,7 +226,7 @@ class TestEncryptDecrypt(unittest.TestCase):
         make_cipher = lambda: get_cipher(b'passphrase', b'\x00' * block_size)
 
         # Test that the same passphrase and IV yield same ciphertext.
-        data = 'a' * block_size * 4
+        data = b'a' * block_size * 4
         crypt_data1 = make_cipher().encrypt(data)
         crypt_data2 = make_cipher().encrypt(data)
         self.assertEqual(crypt_data1, crypt_data2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyCrypto
+pycryptodome

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email='coleifer@gmail.com',
     url='http://github.com/coleifer/beefish/',
     py_modules=['beefish'],
-    install_requires=['pycrypto'],
+    install_requires=['pycryptodome'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This PR is to fix issue #10.

Since the package `pycrypto` is long discontinued, has a lot of unpatched vulnerabilities over the years and has a lot of issues making it not fully compatible with Python3, it is suggested that `pycrypto` be replaced with `pycryptodome`.

Since `pycryptodome` is a fork of `pycrypto` and drop-in replacement officially recommended by `pycrypto` authors, replacing the package will require minimal changes. 